### PR TITLE
Update doc to reference audit/error log queues

### DIFF
--- a/servicecontrol/errorlog-auditlog-behavior.md
+++ b/servicecontrol/errorlog-auditlog-behavior.md
@@ -1,5 +1,5 @@
 ---
-title: ServiceControl Forwarding Queues
+title: ServiceControl Forwarding Log Queues
 summary: Details of the ServiceControl audit and error configuration and forwarding behavior 
 reviewed: 2018-10-05
 ---
@@ -8,19 +8,19 @@ reviewed: 2018-10-05
 
 ServiceControl consumes messages from the audit and error queues and stores these messages locally in its own embedded database. These input queues names are specified at install time.
 
-ServiceControl can also forward these messages to two forwarding queues:
+ServiceControl can also forward these messages to two log queues:
 
- * Error messages are optionally forwarded to the _error_ forwarding queue.
- * Audit messages are optionally forwarded to the _audit_ forwarding queue.
+ * Error messages are optionally forwarded to the _error_ log queue.
+ * Audit messages are optionally forwarded to the _audit_ log queue.
 
 This behavior can be set through ServiceControl Management.
 
 ![](managementutil-queueconfig.png 'width=500')
 
 
-### Error and audit forwarding queues
+### Error and audit log queues
 
-The forwarding queues retain a copy of the original messages ingested by ServiceControl.
+The log queues retain a copy of the original messages ingested by ServiceControl.
 The queues are not directly managed by ServiceControl and are meant as points of external integration.
 
-Note: If external integration is not required, it is strongly recommended to turn forwarding queues off. Otherwise, messages will accumulate unprocessed in the forwarding queue until all available disk space is consumed.
+Note: If external integration is not required, it is strongly recommended to turn forwarding to log queues off. Otherwise, messages will accumulate unprocessed in the forwarding log queue(s) until all available disk space is consumed.


### PR DESCRIPTION
Fixes Particular/ServiceControl/#1568 where there was some confusion with respect to forwarding _to_ the log queues, versus the queues being called forwarding queues. The queues are forwarded _to_, they are not doing the forwarding themselves.

However, I also asked the question as to whether or not the SCMU UI should also be updated to better reflect the nature of the queue to be created? E.g. change _ERROR FORWARDING QUEUE NAME_ to _ERROR FORWARDING LOG QUEUE NAME_.